### PR TITLE
Add link to SSH from linux manual

### DIFF
--- a/1-1-EC2.md
+++ b/1-1-EC2.md
@@ -132,6 +132,7 @@ If you click on your instance ID, you will be able to see it from the list of EC
 
 Make note of the IP address you saw in your instance properties. Use the following guides depending on what operating system you have:
 
+ - [If you are using Linux](https://github.com/DevOpsGirls/devopsgirls-bootcamp/blob/master/8-1-SSH-Login-To-EC2.md)
  - [If you are using a Mac](https://github.com/DevOpsGirls/devopsgirls-bootcamp/blob/master/8-1-SSH-from-Mac.md)
  - [If you are using Windows](https://github.com/DevOpsGirls/devopsgirls-bootcamp/blob/master/8-2-SSH-from-Windows.md)
 

--- a/8-1-SSH-Login-To-EC2.md
+++ b/8-1-SSH-Login-To-EC2.md
@@ -23,7 +23,7 @@ $chmod 400 ~/Downloads/leorentanyag.pem
  
 ### 3) SSH into your instance using your pem key
 
-`ssh -i ~/Downloads/<keyname.pem> ec2-user@<IPv4 Public IP adres>`
+`ssh -i ~/Downloads/<keyname.pem> ec2-user@<IPv4 Public IP adress>`
 
 Example:
 ssh -i ~/Downloads/leorentanyag.pem ec2-user@13.55.214.58


### PR DESCRIPTION
There isn't any link to SSH login from Linux manual file. This PR adds this link.